### PR TITLE
fix: add "type: module" for Next.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Griffin Johnston",
   "license": "MIT",
   "description": "Tree-shakeable CSS and SVG loaders for React",
+  "type": "module",
   "keywords": [
     "react",
     "react-component",


### PR DESCRIPTION
Next.js required you to have "type: module" in your `package.json` in order for it to recognize it as an ESM module, no need for transpilation this way.
Source: 
- https://github.com/vercel/next.js/issues/31518
- https://nextjs.org/blog/next-11-1#es-modules-support

Not sure if this breaks anything else, but would save some hassle/questions in the future.